### PR TITLE
Fix example for configurable data stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ example, to only store data reliably in cookies and LocalStorage:
 import { ImmortalStorage, CookieStore, LocalStorageStore } from 'immortal-db'
 
 const stores = [CookieStore, LocalStorageStore]
-const db = ImmortalStorage(stores)
+const db = new ImmortalStorage(stores)
 
 await db.set('key', JSON.Stringify({1:1}))
 ```


### PR DESCRIPTION
I was trying to set up an ImmortalDB instance with different storages and got this error:

```
Uncaught TypeError: Class constructor ImmortalStorage cannot be invoked without 'new'
```

I think the example should be updated :)