### PR TITLE
fix: not break when cookies are blocked in browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,17 @@ const WINDOW_IS_DEFINED = typeof window !== 'undefined'
 // Stores must implement asynchronous constructor, get(), set(), and remove()
 // methods.
 const DEFAULT_STORES = [CookieStore]
-if (WINDOW_IS_DEFINED && window.indexedDB) {
-  DEFAULT_STORES.push(IndexedDbStore)
-}
-if (WINDOW_IS_DEFINED && window.localStorage) {
-  DEFAULT_STORES.push(LocalStorageStore)
-}
+try {
+  if (WINDOW_IS_DEFINED && window.indexedDB) {
+    DEFAULT_STORES.push(IndexedDbStore)
+  }
+} catch {}
+
+try {
+  if (WINDOW_IS_DEFINED && window.localStorage) {
+    DEFAULT_STORES.push(LocalStorageStore)
+  }
+} catch {}
 
 function arrayGet (arr, index, _default = null) {
   if (index in arr) {


### PR DESCRIPTION
When cookies are blocked in the browser, `window.localStorage` is not accessible by the browser and immortal-db starts giving error. Adding try catch block to fail the error silently.

Example:
![image](https://user-images.githubusercontent.com/4353562/68781181-684fb200-065d-11ea-830d-c1f584d1792c.png)
