### PR TITLE
fix: sort function will return numeric value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,15 +126,12 @@ class ImmortalStorage {
     )
 
     const counted = Array.from(countUniques(values).entries())
-    counted.sort((a, b) => a[1] <= b[1])
+    counted.sort((a, b) => b[1] - a[1])
 
     let value
     const [firstValue, firstCount] = arrayGet(counted, 0, [undefined, 0])
     const [secondValue, secondCount] = arrayGet(counted, 1, [undefined, 0])
-    if (
-      firstCount > secondCount ||
-      (firstCount === secondCount && firstValue !== undefined)
-    ) {
+    if (firstCount >= secondCount && firstValue !== undefined) {
       value = firstValue
     } else {
       value = secondValue


### PR DESCRIPTION
Two points here:
* According to the standard the sort function should return a value > than 0 or < than 0 or 0. Not a boolean, which is the current result of the sort function.
* When selecting between the firstValue or the secondValue, I think undefined should never win.
The rationale is: If we have _some_ undefineds, we can deduce they are from unintended data loss (browser or user deleting the data from some storages). If we had used `ImmortalDB.remove(...)` then all storages would return undefined. Thus in the later case, there will be no doubt all would return undefined. If _some_ non-undefined value survives, then those values should win in this comparison.